### PR TITLE
Update the join parameter order

### DIFF
--- a/php/class.T5_Rewrite_Tag_Post_Format.php
+++ b/php/class.T5_Rewrite_Tag_Post_Format.php
@@ -45,6 +45,6 @@ class T5_Rewrite_Tag_Post_Format extends T5_Rewrite_Tag
 	 */
 	protected function get_examples()
 	{
-		return join( array_keys( get_post_format_strings() ), ', ' );
+		return join( ', ', array_keys( get_post_format_strings() ) );
 	}
 }


### PR DESCRIPTION
In PHP 7.4 the function signature of implode/join where the array is first
and the separator is second is deprecated. In PHP 8.0 it is
no longer allowed and throws an error.
See, https://www.php.net/manual/en/function.implode.php